### PR TITLE
feat(look and feel): Rewrite outgoing messages to ASCII

### DIFF
--- a/ZuluContent/Accounting/AccountHandler.cs
+++ b/ZuluContent/Accounting/AccountHandler.cs
@@ -389,7 +389,7 @@ namespace Server.Misc
             if (!e.Accepted)
                 AccountAttackLimiter.RegisterInvalidAccess(e.State);
 
-            // e.State.PacketEncoder = OutgoingPacketInterceptor.DelocalizeMessage;
+            e.State.PacketEncoder = OutgoingPacketInterceptor.Intercept;
         }
 
         public static bool CheckAccount(Mobile mobCheck, Mobile accCheck)

--- a/ZuluContent/Zulu/Items/SingleClick/SingleClickHandler.cs
+++ b/ZuluContent/Zulu/Items/SingleClick/SingleClickHandler.cs
@@ -99,7 +99,7 @@ namespace ZuluContent.Zulu.Items.SingleClick
 
         private static void SendResponse(Mobile m, Item item, string text)
         {
-            item.LabelTo(m, text.Trim());
+            m.NetState.SendMessage(item.Serial, item.ItemID, MessageType.Label, 0, 3, true, null, "", text);
         }
     }
 }

--- a/ZuluContent/Zulu/Packets/OutgoingPacketInterceptor.cs
+++ b/ZuluContent/Zulu/Packets/OutgoingPacketInterceptor.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Text;
+using Server;
+using Server.Network;
+using static Server.Network.OutgoingMessagePackets;
+
+namespace Scripts.Zulu.Packets
+{
+    public static class OutgoingPacketInterceptor
+    {
+        public static void Intercept(ReadOnlySpan<byte> input, CircularBuffer<byte> output, out int length)
+        {
+            var reader = new SpanReader(input);
+            
+            Span<byte> buffer = new byte[input.Length];
+            var writer = new SpanWriter(buffer);
+            
+            //0x1C : 0xAE
+            switch (reader.ReadByte())
+            {
+                case 0x1C:
+                    Console.WriteLine("Sending ascii message packet");
+                    break;
+                case 0xA3:
+                    Console.WriteLine("Sending unicode message packet");
+                    break;
+                case 0xC1:
+                    Console.WriteLine("Sending CreateMessageLocalized message packet");
+                    break;
+                case 0xCC:
+                    Console.WriteLine("Sending CreateMessageLocalizedAffix message packet");
+                    break;
+            }
+            
+            NetworkCompression.Compress(buffer, output, out length);
+        }
+        
+        public static void DelocalizeMessage(ReadOnlySpan<byte> input, CircularBuffer<byte> output, out int length)
+        {
+            // Localized Message Package
+            if (input[0] != 0xC1)
+            {
+                NetworkCompression.Compress(input, output, out length);
+                return;
+            }
+
+            var reader = new SpanReader(input);
+            reader.Seek(3, SeekOrigin.Current);
+            var serial = (Serial)reader.ReadUInt32();
+            var graphic = reader.ReadInt16();
+            var type = (MessageType)reader.ReadByte();
+            var hue = reader.ReadInt16();
+            var font = reader.ReadInt16();
+            var cliloc = reader.ReadInt32();
+            var name = reader.ReadString(Encoding.ASCII, true, 30);
+            var args = reader.ReadLittleUni();
+            //
+            // reader.ReadByte();
+            // var serial = reader.ReadUInt32();
+            // var graphic = reader.ReadInt16();
+            // var type = (MessageType) reader.ReadByte();
+            // var hue = reader.ReadInt16();
+            // var font = reader.ReadInt16();
+            // var number = reader.ReadInt32();
+            // var flags = AffixType.System;
+            // var name = reader.ReadAscii(30);
+            // var affix = string.Empty;
+            // var args = reader.ReadLittleUni();
+
+
+            if (!ClilocList.Entries.TryGetValue(cliloc, out var text))
+            {
+                NetworkCompression.Compress(input, output, out length);
+                return;
+            }
+
+            Span<byte> buffer = stackalloc byte[GetMaxMessageLength(text)].InitializePacket();
+            var pLength = CreateMessage(
+                buffer,
+                serial,
+                graphic,
+                type,
+                hue,
+                font,
+                true,
+                null,
+                name,
+                text
+            );
+
+            buffer = buffer.SliceToLength(pLength);
+
+            length = NetworkCompression.Compress(buffer, output);
+        }
+    }
+}

--- a/ZuluContent/Zulu/Packets/OutgoingPacketInterceptor.cs
+++ b/ZuluContent/Zulu/Packets/OutgoingPacketInterceptor.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.IO;
 using System.Text;
 using Server;
+using Server.Items;
 using Server.Network;
 using static Server.Network.OutgoingMessagePackets;
 
@@ -12,39 +13,116 @@ namespace Scripts.Zulu.Packets
     {
         public static void Intercept(ReadOnlySpan<byte> input, CircularBuffer<byte> output, out int length)
         {
-            var reader = new SpanReader(input);
-            
-            Span<byte> buffer = new byte[input.Length];
-            var writer = new SpanWriter(buffer);
-            
-            //0x1C : 0xAE
-            switch (reader.ReadByte())
+            switch (input[0])
             {
                 case 0x1C:
                     Console.WriteLine("Sending ascii message packet");
                     break;
-                case 0xA3:
-                    Console.WriteLine("Sending unicode message packet");
+                case 0xBF:
+                    if (input[4] == 0x10)
+                    {
+                        Console.WriteLine("Sending EquipmentInfo message packet");
+                        RewriteEquipmentInfo(input, output, out length);
+                        return;
+                    }
                     break;
+                case 0xAE:
+                    Console.WriteLine("Rewriting unicode message packet");
+                    RewriteUnicodeMessage(input, output, out length);
+                    return;
                 case 0xC1:
-                    Console.WriteLine("Sending CreateMessageLocalized message packet");
-                    break;
                 case 0xCC:
-                    Console.WriteLine("Sending CreateMessageLocalizedAffix message packet");
-                    break;
+                    Console.WriteLine("Rewriting CreateMessageLocalizedAffix message packet");
+                    RewriteMessageLocalized(input, output, out length);
+                    return;
+                    // break;
             }
             
-            NetworkCompression.Compress(buffer, output, out length);
+            length = NetworkCompression.Compress(input, output);
         }
-        
-        public static void DelocalizeMessage(ReadOnlySpan<byte> input, CircularBuffer<byte> output, out int length)
+
+        private static void RewriteEquipmentInfo(ReadOnlySpan<byte> input, CircularBuffer<byte> output, out int length)
         {
-            // Localized Message Package
-            if (input[0] != 0xC1)
+            var reader = new SpanReader(input);
+            reader.Seek(3, SeekOrigin.Current);
+            
+            var sub = reader.ReadInt16();
+            var serial = reader.ReadUInt32();
+            var label = reader.ReadInt32();
+
+            var item = World.FindItem(serial);
+
+            if ( !ClilocList.Entries.TryGetValue(label, out var text))
             {
-                NetworkCompression.Compress(input, output, out length);
+                length = NetworkCompression.Compress(input, output);
                 return;
             }
+
+            var res = item switch
+            {
+                BaseClothing clothing => clothing.Resource,
+                BaseWeapon weapon => weapon.Resource,
+                BaseArmor armor => armor.Resource,
+                BaseJewel jewel => jewel.Resource,
+                _ => CraftResource.None
+            };
+
+            if (res != CraftResource.None)
+                text = $"{CraftResources.GetName(res)} {text}";
+            
+            var buffer = stackalloc byte[GetMaxMessageLength(text)].InitializePacket();
+            var pLength = CreateMessage(
+                buffer,
+                serial,
+                item.ItemID,
+                MessageType.Label,
+                0,
+                3,
+                true,
+                null,
+                "",
+                text
+            );
+
+            buffer = buffer.SliceToLength(pLength);
+            length = NetworkCompression.Compress(buffer, output);
+        }
+        
+        private static void RewriteUnicodeMessage(ReadOnlySpan<byte> input, CircularBuffer<byte> output, out int length)
+        {
+            var reader = new SpanReader(input);
+            reader.Seek(3, SeekOrigin.Current);
+
+            var serial = reader.ReadUInt32();
+            var graphic = reader.ReadInt16();
+            var type = (MessageType) reader.ReadByte();
+            var hue = reader.ReadInt16();
+            var font = reader.ReadInt16();
+            var lang = reader.ReadAscii(4);
+            var name = reader.ReadAscii(30);
+            var text = reader.ReadBigUni();
+            
+            var buffer = stackalloc byte[GetMaxMessageLength(text)].InitializePacket();
+            var pLength = CreateMessage(
+                buffer,
+                serial,
+                graphic,
+                type,
+                hue,
+                font,
+                true,
+                null,
+                name,
+                text
+            );
+
+            buffer = buffer.SliceToLength(pLength);
+            length = NetworkCompression.Compress(buffer, output);
+        }
+        
+        private static void RewriteMessageLocalized(ReadOnlySpan<byte> input, CircularBuffer<byte> output, out int length)
+        {
+            var isAffix = input[0] == 0xCC;
 
             var reader = new SpanReader(input);
             reader.Seek(3, SeekOrigin.Current);
@@ -53,30 +131,34 @@ namespace Scripts.Zulu.Packets
             var type = (MessageType)reader.ReadByte();
             var hue = reader.ReadInt16();
             var font = reader.ReadInt16();
-            var cliloc = reader.ReadInt32();
-            var name = reader.ReadString(Encoding.ASCII, true, 30);
-            var args = reader.ReadLittleUni();
-            //
-            // reader.ReadByte();
-            // var serial = reader.ReadUInt32();
-            // var graphic = reader.ReadInt16();
-            // var type = (MessageType) reader.ReadByte();
-            // var hue = reader.ReadInt16();
-            // var font = reader.ReadInt16();
-            // var number = reader.ReadInt32();
-            // var flags = AffixType.System;
-            // var name = reader.ReadAscii(30);
-            // var affix = string.Empty;
-            // var args = reader.ReadLittleUni();
-
-
-            if (!ClilocList.Entries.TryGetValue(cliloc, out var text))
+            var label = reader.ReadInt32();
+            var flags = isAffix ? (AffixType) reader.ReadByte() : AffixType.System;
+            var name = reader.ReadAscii(30);
+            var affix = isAffix ? reader.ReadAscii() : string.Empty;
+            var args = isAffix ? reader.ReadBigUni() : reader.ReadLittleUni();
+            
+            if (!ClilocList.Entries.TryGetValue(label, out var clilocEntry))
             {
-                NetworkCompression.Compress(input, output, out length);
+                length = NetworkCompression.Compress(input, output);
                 return;
             }
+            
+            var text = ClilocList.Translate(clilocEntry, args);
+            
+            if (isAffix)
+            {
+                text = flags switch
+                {
+                    AffixType.Append => $"{text}{affix}",
+                    AffixType.Prepend => $"{affix}{text}",
+                    _ => $"{affix}{text}"
+                };
 
-            Span<byte> buffer = stackalloc byte[GetMaxMessageLength(text)].InitializePacket();
+                if ((flags & AffixType.System) != 0)
+                    type = MessageType.System;
+            }
+
+            var buffer = stackalloc byte[GetMaxMessageLength(text)].InitializePacket();
             var pLength = CreateMessage(
                 buffer,
                 serial,


### PR DESCRIPTION
Overrides the default `NetState.PacketEncoder` to a custom interceptor that checks outgoing packets for Unicode/Localization/EquipmentInfo packets and turns them into ASCII messages.

This mimics the look and feel of older POL and ZH shards as all messages by default are ASCII in a certain font.

Can be toggled using the `outgoingPacketInterceptor.rewriteMessagesToAscii` modernuo.json setting.

Before:
![image](https://user-images.githubusercontent.com/1094679/107112477-07d51200-68ac-11eb-8da3-7b17918f1884.png)

Now:
![image](https://user-images.githubusercontent.com/1094679/107112504-2dfab200-68ac-11eb-829a-67762ca78410.png)


