### PR TITLE
Dockerfile optimized for development process, fixed error with CUE binary download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /source
 RUN apt-get update && \
    apt-get install -y -q --no-install-recommends \
    ca-certificates=20211016~20.04.1 \
-   rsync=3.1.3-8ubuntu0.3 \
-   && apt-get clean \
-   && rm -r /var/lib/apt/lists/*
+   rsync=3.1.3-8ubuntu0.3 && \
+   apt-get clean && \
+   rm -r /var/lib/apt/lists/*
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ ARG UID=1000
 RUN groupadd -g ${UID} ${USER} && \
     useradd -l -u ${UID} -g ${USER} -s /bin/sh ${USER}
 
-USER ${user}
-
 RUN apt-get update && \
    apt-get install -y -q --no-install-recommends \
    ca-certificates=20211016~20.04.1 \
@@ -43,6 +41,7 @@ RUN apt-get update && \
 
 COPY --chown=${USER} --from=builder /source/ModernUO/Distribution /app
 
+USER ${USER}
 WORKDIR /app
 EXPOSE 2593
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN apt-get update && \
 
 COPY . .
 
-RUN rm -rf ModernUO && \
-   git submodule update --init --recursive && \
+RUN git submodule update --init --recursive && \
    dotnet publish -r linux-x64 -c Release
 
 # Server

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS builder
 
 WORKDIR /source
 
-RUN apt-get update \
-   && apt-get install -y -q --no-install-recommends \
-   ca-certificates rsync \
+RUN apt-get update && \
+   apt-get install -y -q --no-install-recommends \
+   ca-certificates=20211016~20.04.1 \
+   rsync=3.1.3-8ubuntu0.3 \
    && apt-get clean \
    && rm -r /var/lib/apt/lists/*
 
@@ -29,14 +30,14 @@ USER ${user}
 
 RUN apt-get update && \
    apt-get install -y -q --no-install-recommends \
-   ca-certificates \
-   libargon2-1 \
-   libargon2-dev \
-   zlib1g \
-   zlib1g-dev \
-   libicu66 \
-   libicu-dev \
-   zstd \
+   ca-certificates=20211016~20.04.1 \
+   libargon2-1=0~20171227-0.2 \
+   libargon2-dev=0~20171227-0.2 \
+   zlib1g=1:1.2.11.dfsg-2ubuntu1.3 \
+   zlib1g-dev=1:1.2.11.dfsg-2ubuntu1.3 \
+   libicu66=66.1-2ubuntu2.1 \
+   libicu-dev=66.1-2ubuntu2.1 \
+   zstd=1.4.4+dfsg-3ubuntu0.1 \
    && apt-get clean \
    && rm -r /var/lib/apt/lists/*
 

--- a/ZuluContent/=DEV=/JsHammer.cs
+++ b/ZuluContent/=DEV=/JsHammer.cs
@@ -36,8 +36,8 @@ public class JsHammer : BaseBashing
     private async void SendGump(Mobile from)
     {
         var response = await new JsGump<dynamic, JsGumpResponse>(
-            "TestGump", 
-            from, 
+            "TestGump",
+            from,
             new
             {
                 serial = Serial.Value,

--- a/ZuluContent/Configuration/ZhConfig.cs
+++ b/ZuluContent/Configuration/ZhConfig.cs
@@ -45,10 +45,10 @@ namespace Server
 
             DefaultSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
             DefaultSerializerOptions.PropertyNameCaseInsensitive = true;
-            
+
             _root = LoadCueConfiguration();
         }
-        
+
         private static RootConfiguration LoadCueConfiguration()
         {
             #if DEBUG
@@ -76,7 +76,7 @@ namespace Server
                 new EnumerationOptions { RecurseSubdirectories = true });
             var jsonCacheLastWrite = File.GetLastWriteTimeUtc(jsonCachePath);
             var lastWrite = files.Length > 0 ? files.Select(File.GetLastWriteTimeUtc).Max() : jsonCacheLastWrite;
-            
+
             if (!File.Exists(jsonCachePath) || lastWrite != jsonCacheLastWrite)
             {
                 Logger.Information("CUE Configuration is out of date, rebuilding via cli {0} ... ", $"cue {cueArgs}");
@@ -86,12 +86,12 @@ namespace Server
                     throw new ApplicationException(
                         $"Failed to run cli command line, received non-zero exit code {exitCode}: {stderr}"
                     );
-                    
+
                 Logger.Information("Finished building CUE configuration.");
 
                 File.SetLastWriteTime(jsonCachePath, lastWrite);
             }
-                
+
             return DeserializeJsonConfig<RootConfiguration>(jsonCachePath);
         }
 
@@ -99,21 +99,21 @@ namespace Server
         public static T DeserializeJsonConfig<T>(string configFile, JsonSerializerOptions options = null)
         {
             var path = Path.Combine(Server.Core.BaseDirectory, configFile);
-            
+
             if (!File.Exists(path))
             {
                 throw new FileLoadException($"Configuration not found {path}!");
             }
-            
+
             Logger.Information("Deserializing {0} ... ", path);
 
             var config = JsonConfig.Deserialize<T>(path, options ?? DefaultSerializerOptions);
 
             if (config == null)
                 throw new DataException($"DeserializeJsonConfig<{typeof(T).Name}>: failed to deserialize {path}!");
-            
+
             Logger.Information("Finished deserialization.");
-            
+
             return config;
         }
     }

--- a/ZuluContent/Cue/CueHelpers.cs
+++ b/ZuluContent/Cue/CueHelpers.cs
@@ -28,14 +28,20 @@ namespace Scripts.Cue
                 [JsonPropertyName("browser_download_url")]
                 public string Url { get; init; }
             }
-        } 
-        
+        }
+
         public static void DownloadCueCli(string destination, string fileName)
         {
             if (!Directory.Exists(destination))
                 Directory.CreateDirectory(destination);
 
-            using (var client = new HttpClient())
+            using (var client = new HttpClient(
+                new HttpClientHandler
+                {
+                    AllowAutoRedirect = true,
+                    MaxAutomaticRedirections = 5
+                }
+            ))
             {
                 client.BaseAddress = new Uri("https://api.github.com");
                 client.DefaultRequestHeaders.Add("User-Agent", "Anything");
@@ -51,7 +57,7 @@ namespace Scripts.Cue
                 {
                     if (!a.Url.Contains(arch, StringComparison.InvariantCultureIgnoreCase))
                         return false;
-                    
+
                     if (Core.IsWindows && a.Url.Contains("windows", StringComparison.InvariantCultureIgnoreCase))
                         return true;
                     if (Core.IsDarwin && a.Url.Contains("darwin", StringComparison.InvariantCultureIgnoreCase))
@@ -84,7 +90,7 @@ namespace Scripts.Cue
             if (!File.Exists(Path.Combine(destination, fileName)))
                 throw new ApplicationException($"Failed to extract cue cli to ${destination}");
         }
-        
+
         public static (string stdout, string stderr, int exitCode) RunCueCli(string workingDir, params string[] args)
         {
             var cueFileName = $"cue{(Core.IsWindows ? ".exe" : "")}";
@@ -95,19 +101,19 @@ namespace Scripts.Cue
             {
                 Utility.PushColor(ConsoleColor.Yellow);
                 Console.Write("CUE cli is missing, downloading latest GitHub release ... ");
-                
+
                 DownloadCueCli(cueCliRoot, cueFileName);
-                if (Core.IsLinux || Core.IsDarwin) 
+                if (Core.IsLinux || Core.IsDarwin)
                     Process.Start("chmod", $"755 {cueCliPath}");
-                
+
                 Utility.PopColor();
                 Utility.PushColor(ConsoleColor.Green);
                 Console.Write("done; ");
                 Utility.PopColor();
                 Console.Write("running cli ... ");
 
-            } 
-            
+            }
+
             var startInfo = new ProcessStartInfo
             {
                 Arguments = string.Join(" ", args),

--- a/ZuluContent/Cue/Tar.cs
+++ b/ZuluContent/Cue/Tar.cs
@@ -25,10 +25,22 @@ namespace Scripts.Cue
         /// <param name="outputDir">Output directory to write the files.</param>
         public static void ExtractTarGz(Stream stream, string outputDir)
         {
+            // A GZipStream is not seekable, so copy it first to a MemoryStream
             using (var gzip = new GZipStream(stream, CompressionMode.Decompress))
             {
-                // removed convertation to MemoryStream
-                ExtractTar(gzip, outputDir);
+                const int chunk = 4096;
+                using (var memStr = new MemoryStream())
+                {
+                    int read;
+                    var buffer = new byte[chunk];
+                    while ((read = gzip.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        memStr.Write(buffer, 0, read);
+                    }
+
+                    memStr.Seek(0, SeekOrigin.Begin);
+                    ExtractTar(memStr, outputDir);
+                }
             }
         }
 


### PR DESCRIPTION
A bit modified `Dockerfile` to match some best practices, pinned package versions and reordered steps - so after every change of the source code - you don't need to reinstall packages, cached layers will be used ( pretty useful for the local development )

As for `cue` helpers - it seems like [this commit](https://github.com/it-sova/zuluhotel-modernuo/commit/17e7945c37bfc773340843f55c4998256e2dc0b6) broke `ExtractTarGz` function ( at least - it is broken at that moment, an error occurs on the runtime stage - that's why CI/CD is green ), now server is able to download `cue` binary at startup and process all required files:
```shell
[21:41:12 INF] CUE Configuration is out of date, rebuilding via cli CUE cli is missing, downloading latest GitHub release ... cue export --force --outfile .zhcache.json Zuluhotel.cue ...  <s:Server.ZhConfig>
done; running cli ... [21:41:29 INF] Finished building CUE configuration. <s:Server.ZhConfig>
```